### PR TITLE
Replace leftover Frappe CRM references

### DIFF
--- a/crm/locale/ar.po
+++ b/crm/locale/ar.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "كلف إلى"
 msgid "Assignment"
 msgstr "مهمة"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "قاعدة الاحالة"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "تعليقات"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "الوارد"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "مالك الزبون المحتمل"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "مجموع العطلات"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/bs.po
+++ b/crm/locale/bs.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr "<b>META</b>"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr "<b>PREČICE</b>"
@@ -101,7 +101,7 @@ msgstr "<b>PREČICE</b>"
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr "<p>Poštovani {{ lead_name }},</p>\\n\\n<p>Ovo je podsjetnik za plaćanje {{ grand_total }}.</p>\\n\\n<p>Hvala,</p>\\n<p>Frappé</p>"
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr "<span class=\"h5\"><b>PORTAL</b></span>"
@@ -365,7 +365,7 @@ msgstr "Dodijeljeno"
 msgid "Assignment"
 msgstr "Dodjela"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Pravilo Dodjele"
@@ -540,7 +540,7 @@ msgstr "Obavještenje"
 msgid "CRM Organization"
 msgstr "Organizacija"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr "Stranica Portala"
@@ -774,7 +774,7 @@ msgstr "Komentari"
 msgid "Communication Status"
 msgstr "Status Konverzacije"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr "Status Konverzacije"
@@ -841,7 +841,7 @@ msgstr "Kontakt je uklonjen"
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "Odgovorni"
 msgid "Deal Status"
 msgstr "Status Dogovora"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr "Status Dogovora"
@@ -1009,7 +1009,7 @@ msgstr "Odgovorni Dogovora"
 msgid "Deal updated"
 msgstr "Dogovor ažuriran"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr "Skripta Forme je uspješno ažurirana"
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr "Podrška Prodaje"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Dolazeći"
 msgid "Incoming call..."
 msgstr "Dolazni poziv..."
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr "Industrije"
@@ -2054,12 +2054,12 @@ msgstr "Odgovorni"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr "Odgovorni za Potencijalnog Klijenta ne može biti isti kao i adresa e-pošte potencijalnog klijenta"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr "Izvor Potencijalnog Klijenta"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr "Status Potencijalnog Klijenta"
@@ -2068,7 +2068,7 @@ msgstr "Status Potencijalnog Klijenta"
 msgid "Lead updated"
 msgstr "Potencijalni Klijent ažuriran"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr "Logo Organizacije"
 msgid "Organization updated"
 msgstr "Organizacija ažurirana"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr "Redovi"
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr "Medij Telefonije"
 msgid "Telephony Settings"
 msgstr "Postavke Telefonije"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr "Distrikti"
@@ -3599,8 +3599,8 @@ msgid "Total Holidays"
 msgstr "Ukupno Praznika"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
-msgstr "Isprobaj Frappe CRM besplatno uz 14-dnevnu probnu verziju."
+msgid "Try Nexo CRM for free with a 14-day trial."
+msgstr "Isprobaj Nexo CRM besplatno uz 14-dnevnu probnu verziju."
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'

--- a/crm/locale/de.po
+++ b/crm/locale/de.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "Zugewiesen zu"
 msgid "Assignment"
 msgstr "Zuordnung"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Zuweisungsregel"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "Kommentare"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "Besitzer des Deals"
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Eingehend"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "Verantwortlicher"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr "Der Eigentümer des Interessenten darf nicht mit der E-Mail-Adresse des Interessenten übereinstimmen"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Insgesamt freie Tage"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/eo.po
+++ b/crm/locale/eo.po
@@ -87,12 +87,12 @@ msgstr "crwdns152679:0crwdne152679:0"
 msgid "51-200"
 msgstr "crwdns152681:0crwdne152681:0"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr "crwdns152683:0crwdne152683:0"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr "crwdns152685:0crwdne152685:0"
@@ -101,7 +101,7 @@ msgstr "crwdns152685:0crwdne152685:0"
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr "crwdns152687:0{{ lead_name }}crwdnd152687:0{{ grand_total }}crwdne152687:0"
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr "crwdns152689:0crwdne152689:0"
@@ -365,7 +365,7 @@ msgstr "crwdns152791:0crwdne152791:0"
 msgid "Assignment"
 msgstr "crwdns152793:0crwdne152793:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "crwdns152795:0crwdne152795:0"
@@ -540,7 +540,7 @@ msgstr "crwdns152863:0crwdne152863:0"
 msgid "CRM Organization"
 msgstr "crwdns152865:0crwdne152865:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr "crwdns152867:0crwdne152867:0"
@@ -774,7 +774,7 @@ msgstr "crwdns152957:0crwdne152957:0"
 msgid "Communication Status"
 msgstr "crwdns152959:0crwdne152959:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr "crwdns152961:0crwdne152961:0"
@@ -841,7 +841,7 @@ msgstr "crwdns152987:0crwdne152987:0"
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "crwdns153037:0crwdne153037:0"
 msgid "Deal Status"
 msgstr "crwdns153039:0crwdne153039:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr "crwdns153041:0crwdne153041:0"
@@ -1009,7 +1009,7 @@ msgstr "crwdns153043:0crwdne153043:0"
 msgid "Deal updated"
 msgstr "crwdns153045:0crwdne153045:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr "crwdns153279:0crwdne153279:0"
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr "crwdns153281:0crwdne153281:0"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "crwdns153347:0crwdne153347:0"
 msgid "Incoming call..."
 msgstr "crwdns153349:0crwdne153349:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr "crwdns153351:0crwdne153351:0"
@@ -2054,12 +2054,12 @@ msgstr "crwdns153433:0crwdne153433:0"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr "crwdns153435:0crwdne153435:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr "crwdns153437:0crwdne153437:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr "crwdns153439:0crwdne153439:0"
@@ -2068,7 +2068,7 @@ msgstr "crwdns153439:0crwdne153439:0"
 msgid "Lead updated"
 msgstr "crwdns153441:0crwdne153441:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr "crwdns153677:0crwdne153677:0"
 msgid "Organization updated"
 msgstr "crwdns153679:0crwdne153679:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr "crwdns153833:0crwdne153833:0"
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr "crwdns153955:0crwdne153955:0"
 msgid "Telephony Settings"
 msgstr "crwdns153957:0crwdne153957:0"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr "crwdns153959:0crwdne153959:0"
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "crwdns154007:0crwdne154007:0"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr "crwdns154009:0crwdne154009:0"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/es.po
+++ b/crm/locale/es.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "Asignado a"
 msgid "Assignment"
 msgstr "Asignación"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Regla de asignación"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "Comentarios"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Entrante"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "Propietario de la iniciativa"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Vacaciones Totales"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/fa.po
+++ b/crm/locale/fa.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "اختصاص یافته به"
 msgid "Assignment"
 msgstr "تخصیص"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "قانون تخصیص"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "نظرات"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "صاحب معامله"
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "ورودی"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "مالک اصلی"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr "مالک اصلی نمی‌تواند با آدرس ایمیل اصلی یکسان باشد"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "کل تعطیلات"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/fr.po
+++ b/crm/locale/fr.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "Assigné À"
 msgid "Assignment"
 msgstr "Affectation"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Règle d&#39;assignation"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "Commentaires"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "Resp. de l'opportunité"
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Entrant"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "Responsable du Prospect"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Total des vacances"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/hr.po
+++ b/crm/locale/hr.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr ""
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/hu.po
+++ b/crm/locale/hu.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Hozzárendelési szabály"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Ünnepek összesen"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/main.pot
+++ b/crm/locale/main.pot
@@ -1,11 +1,11 @@
-# Translations template for Frappe CRM.
+# Translations template for Nexo CRM.
 # Copyright (C) 2025 Frappe Technologies Pvt. Ltd.
-# This file is distributed under the same license as the Frappe CRM project.
+# This file is distributed under the same license as the Nexo CRM project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Frappe CRM VERSION\n"
+"Project-Id-Version: Nexo CRM VERSION\n"
 "Report-Msgid-Bugs-To: shariq@frappe.io\n"
 "POT-Creation-Date: 2025-06-22 09:36+0000\n"
 "PO-Revision-Date: 2025-06-22 09:36+0000\n"
@@ -105,12 +105,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -119,7 +119,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr ""
@@ -599,7 +599,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -950,7 +950,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:261 frontend/src/pages/MobileContact.vue:233
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:512 frontend/src/pages/MobileContact.vue:310
 #: frontend/src/pages/MobileDeal.vue:397
@@ -1893,11 +1893,11 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:597
-msgid "Frappe CRM mobile"
+msgid "Nexo CRM mobile"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2382,12 +2382,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2396,7 +2396,7 @@ msgstr ""
 msgid "Lead updated successfully"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:501 frontend/src/pages/MobileLead.vue:298
 msgid "Leads"
@@ -3061,7 +3061,7 @@ msgstr ""
 msgid "Organization logo"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:211
 #: frontend/src/pages/Organization.vue:246
@@ -3529,7 +3529,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3991,7 +3991,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""

--- a/crm/locale/pl.po
+++ b/crm/locale/pl.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr "<p>Drogi {{ lead_name }},</p>\\n\\n<p>Przypominamy o zapłacie {{ grand_total }}.</p>\\n\\n<p>Dziękuję,</p>\\n<p>Frappé</p>"
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Całkowita liczba dni wolnych"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/pt.po
+++ b/crm/locale/pt.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "Atribuído A"
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "Comentários"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Entrada"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr ""
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/ru.po
+++ b/crm/locale/ru.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Всего праздников"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/sv.po
+++ b/crm/locale/sv.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr "<b>META</b>"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr "<b>GENVÄGAR</b>"
@@ -101,7 +101,7 @@ msgstr "<b>GENVÄGAR</b>"
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr "<p>Bästa {{ lead_name }},</p>\\n\\n<p>Detta är en påminnelse om betalningen av {{ grand_total }}.</p>\\n\\n<p>Tack,</p>\\n<p>.</p>"
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr "<span class=\"h5\"><b>PORTAL</b></span>"
@@ -365,7 +365,7 @@ msgstr "Tilldelad Till"
 msgid "Assignment"
 msgstr "Tilldelning"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Tilldelning Regel"
@@ -540,7 +540,7 @@ msgstr "Aviseringar"
 msgid "CRM Organization"
 msgstr "Organisation"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr "Portal Sida"
@@ -774,7 +774,7 @@ msgstr "Kommentarer"
 msgid "Communication Status"
 msgstr "Konversation Status"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr "Konversation Statusar"
@@ -841,7 +841,7 @@ msgstr "Kontakt borttagen"
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "Ansvarig"
 msgid "Deal Status"
 msgstr "Affär Status"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr "Affär Status"
@@ -1009,7 +1009,7 @@ msgstr "Affär Ansvarig"
 msgid "Deal updated"
 msgstr "Affär uppdaterad"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr "Formulär Skript uppdaterad"
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr "Säljstöd"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Inkommande"
 msgid "Incoming call..."
 msgstr "Inkommande samtal..."
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr "Branscher"
@@ -2054,12 +2054,12 @@ msgstr "Potentiell Kund Ansvarig"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr "Potentiell Kund Ansvarig kan inte vara samma som Potentiell Kund E-post Adress"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr "Potentiell Kund Källor"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr "Potentiell Kund Statusar"
@@ -2068,7 +2068,7 @@ msgstr "Potentiell Kund Statusar"
 msgid "Lead updated"
 msgstr "Potentiell Kund uppdaterad"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr "Organisation Logotyp"
 msgid "Organization updated"
 msgstr "Organisation Uppdaterad"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr "Rader"
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr "Telefoni Medium"
 msgid "Telephony Settings"
 msgstr "Telefoni Inställningar"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr "Distrikt"
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Totalt Helg Dagar"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr "Prova Säljstöd gratis med 14-dagars testperiod."
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/th.po
+++ b/crm/locale/th.po
@@ -87,12 +87,12 @@ msgstr ""
 msgid "51-200"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr ""
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr ""
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/tr.po
+++ b/crm/locale/tr.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "Atama"
 msgid "Assignment"
 msgstr "Atama"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "Atama Kuralı"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "Yorumlar"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr "Anlaşma Sahibi"
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "Gelen"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "Sorumlu Kişi"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr "Potansiyel Müşteri Sahibi, Potansiyel Müşteri E-posta Adresi ile aynı olamaz"
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr "Toplam Tatil Günü"
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'

--- a/crm/locale/zh.po
+++ b/crm/locale/zh.po
@@ -87,12 +87,12 @@ msgstr "501-1000"
 msgid "51-200"
 msgstr "51-200"
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
 msgstr ""
 
-#. Paragraph text in the Frappe CRM Workspace
+#. Paragraph text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
 msgstr ""
 
-#. Header text in the Frappe CRM Workspace
+#. Header text in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr "已分配给"
 msgid "Assignment"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
 msgstr "作业规则"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "CRM Organization"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr "评论"
 msgid "Communication Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Contact.vue:242 frontend/src/pages/MobileContact.vue:235
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Deal Status"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Deal updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:471 frontend/src/pages/MobileContact.vue:314
 #: frontend/src/pages/MobileDeal.vue:393
@@ -1629,7 +1629,7 @@ msgstr ""
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
-msgid "Frappe CRM"
+msgid "Nexo CRM"
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
@@ -1819,7 +1819,7 @@ msgstr "来料检验"
 msgid "Incoming call..."
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
 msgstr ""
@@ -2054,12 +2054,12 @@ msgstr "线索负责人"
 msgid "Lead Owner cannot be same as the Lead Email Address"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Lead updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Lead.vue:461 frontend/src/pages/MobileLead.vue:297
 msgid "Leads"
@@ -2689,7 +2689,7 @@ msgstr ""
 msgid "Organization updated"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/MobileOrganization.vue:222
 #: frontend/src/pages/Organization.vue:243
@@ -3086,7 +3086,7 @@ msgstr ""
 #. Label of the sla (Link) field in DocType 'CRM Deal'
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
 #. Label of the sla (Link) field in DocType 'CRM Lead'
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Telephony Settings"
 msgstr ""
 
-#. Label of a shortcut in the Frappe CRM Workspace
+#. Label of a shortcut in the Nexo CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Total Holidays"
 msgstr ""
 
 #: frontend/src/components/SignupBanner.vue:12
-msgid "Try Frappe CRM for free with a 14-day trial."
+msgid "Try Nexo CRM for free with a 14-day trial."
 msgstr ""
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'


### PR DESCRIPTION
## Summary
- rename `Frappe CRM` to `Nexo CRM` throughout locale files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686126a4ddc883208757ac3b493cf125